### PR TITLE
Add PLM workspace interface for product setup

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,204 @@
+const brandButtons = Array.from(document.querySelectorAll('.toggle-group button'));
+const seasonSelect = document.getElementById('season');
+const departmentSelect = document.getElementById('department');
+const continueButton = document.getElementById('continue-btn');
+const briefingPanel = document.getElementById('briefing-panel');
+const briefingForm = document.getElementById('briefing-form');
+const briefingSummaryPanel = document.getElementById('briefing-summary');
+const briefingSummaryList = briefingSummaryPanel?.querySelector('dl') ?? null;
+const editBriefButton = document.getElementById('edit-brief');
+const workspacePanel = document.getElementById('workspace-panel');
+const selectionSummary = document.getElementById('selection-summary');
+const moduleNav = document.querySelector('.module-nav');
+const moduleContent = document.getElementById('module-content');
+
+const moduleTemplates = {
+  article: document.getElementById('article-template'),
+  materials: document.getElementById('materials-template'),
+  colors: document.getElementById('colors-template'),
+  calendar: document.getElementById('calendar-template'),
+};
+
+let selectedBrand = '';
+let selectedSeason = '';
+let selectedDepartment = '';
+
+const moduleData = {
+  article: [
+    { style: 'MST-212', category: 'Outerwear', status: 'Tech Pack', milestone: 'Fit Review', badge: 'info' },
+    { style: 'MTP-114', category: 'Bottoms', status: 'Proto Sample', milestone: 'Proto Approval', badge: 'warning' },
+    { style: 'MKN-408', category: 'Knitwear', status: 'Bulk Ready', milestone: 'PO Placement', badge: 'success' },
+  ],
+  materials: [
+    { name: 'Recycled Nylon Ripstop', composition: '100% Recycled Nylon', supplier: 'EverSource Mills', status: 'Nominated', badge: 'info' },
+    { name: 'Organic Cotton Fleece', composition: '95% Cotton / 5% Spandex', supplier: 'GreenLoop Textiles', status: 'Approved', badge: 'success' },
+    { name: 'Matte Rubberized Zipper', composition: 'TPU + Metal', supplier: 'ZipTech', status: 'Pending Testing', badge: 'warning' },
+  ],
+  colors: [
+    { color: 'Midnight Navy', code: 'MN-402', finish: 'Matte', approval: 'Approved', badge: 'success' },
+    { color: 'Canyon Clay', code: 'CC-215', finish: 'Pigment Dye', approval: 'Lab Dip', badge: 'info' },
+    { color: 'Frost Grey', code: 'FG-117', finish: 'Heather', approval: 'Pending', badge: 'warning' },
+  ],
+  calendar: [
+    { milestone: 'Line Adoption', owner: 'Merchandising', dueDate: 'May 12, 2024', status: 'On Track', badge: 'success' },
+    { milestone: 'Proto Fit Review', owner: 'Technical Design', dueDate: 'June 03, 2024', status: 'Scheduled', badge: 'info' },
+    { milestone: 'Bulk Fabric Commit', owner: 'Production', dueDate: 'July 22, 2024', status: 'Risk', badge: 'warning' },
+  ],
+};
+
+if (briefingSummaryPanel) {
+  briefingSummaryPanel.setAttribute('aria-hidden', 'true');
+}
+
+function updateContinueState() {
+  const hasBrand = Boolean(selectedBrand);
+  const hasSeason = seasonSelect.value !== '';
+  const hasDepartment = departmentSelect.value !== '';
+  continueButton.disabled = !(hasBrand && hasSeason && hasDepartment);
+}
+
+function updateSummary() {
+  const entries = [selectedBrand, selectedSeason, selectedDepartment].map((value) => value || '-');
+  const targets = [selectionSummary, briefingSummaryList].filter(Boolean);
+  targets.forEach((node) => {
+    node.querySelectorAll('dd').forEach((dd, index) => {
+      dd.textContent = entries[index];
+    });
+  });
+}
+
+function populateTable(moduleKey) {
+  const template = moduleTemplates[moduleKey];
+  if (!template) return;
+
+  const fragment = template.content.cloneNode(true);
+  const tableBody = fragment.querySelector('tbody');
+  const data = moduleData[moduleKey];
+
+  data.forEach((item) => {
+    const row = document.createElement('tr');
+
+    switch (moduleKey) {
+      case 'article': {
+        row.innerHTML = `
+          <td>${item.style}</td>
+          <td>${item.category}</td>
+          <td><span class="badge badge--${item.badge}">${item.status}</span></td>
+          <td>${item.milestone}</td>
+        `;
+        break;
+      }
+      case 'materials': {
+        row.innerHTML = `
+          <td>${item.name}</td>
+          <td>${item.composition}</td>
+          <td>${item.supplier}</td>
+          <td><span class="badge badge--${item.badge}">${item.status}</span></td>
+        `;
+        break;
+      }
+      case 'colors': {
+        row.innerHTML = `
+          <td>${item.color}</td>
+          <td>${item.code}</td>
+          <td>${item.finish}</td>
+          <td><span class="badge badge--${item.badge}">${item.approval}</span></td>
+        `;
+        break;
+      }
+      case 'calendar': {
+        row.innerHTML = `
+          <td>${item.milestone}</td>
+          <td>${item.owner}</td>
+          <td>${item.dueDate}</td>
+          <td><span class="badge badge--${item.badge}">${item.status}</span></td>
+        `;
+        break;
+      }
+      default:
+        break;
+    }
+
+    tableBody.appendChild(row);
+  });
+
+  const summaryBar = document.createElement('footer');
+  summaryBar.className = 'module__context';
+  const contextDetails = [selectedBrand, selectedSeason, selectedDepartment].filter(Boolean).join(' · ');
+  summaryBar.innerHTML = `
+    <div class="module__context-label">Showing ${moduleData[moduleKey].length} records</div>
+    <div class="module__context-pill">${contextDetails || 'Context pending'}</div>
+  `;
+
+  fragment.querySelector('.module').appendChild(summaryBar);
+
+  moduleContent.replaceChildren(fragment);
+}
+
+function setActiveModule(button) {
+  if (!button) return;
+  moduleNav.querySelectorAll('.module-nav__item').forEach((item) => {
+    item.classList.toggle('is-active', item === button);
+  });
+  const moduleKey = button.dataset.module;
+  populateTable(moduleKey);
+}
+
+brandButtons.forEach((button) => {
+  button.addEventListener('click', () => {
+    selectedBrand = button.dataset.brand;
+    brandButtons.forEach((other) => {
+      const isActive = other === button;
+      other.setAttribute('aria-pressed', String(isActive));
+      if (!isActive) {
+        other.blur();
+      }
+    });
+    updateContinueState();
+  });
+});
+
+briefingForm.addEventListener('input', () => {
+  selectedSeason = seasonSelect.value;
+  selectedDepartment = departmentSelect.value;
+  updateContinueState();
+});
+
+briefingForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+  updateSummary();
+  briefingForm.setAttribute('aria-hidden', 'true');
+  briefingPanel.classList.add('panel--complete');
+  if (briefingSummaryPanel) {
+    briefingSummaryPanel.hidden = false;
+    briefingSummaryPanel.setAttribute('aria-hidden', 'false');
+  }
+  workspacePanel.classList.remove('panel--hidden');
+  workspacePanel.setAttribute('aria-hidden', 'false');
+  workspacePanel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  const defaultModule = moduleNav.querySelector('[data-module="article"]');
+  setActiveModule(defaultModule);
+});
+
+moduleNav.addEventListener('click', (event) => {
+  const button = event.target.closest('.module-nav__item');
+  if (!button) return;
+  setActiveModule(button);
+});
+
+if (editBriefButton) {
+  editBriefButton.addEventListener('click', () => {
+    briefingForm.setAttribute('aria-hidden', 'false');
+    briefingPanel.classList.remove('panel--complete');
+    if (briefingSummaryPanel) {
+      briefingSummaryPanel.hidden = true;
+      briefingSummaryPanel.setAttribute('aria-hidden', 'true');
+    }
+    workspacePanel.classList.add('panel--hidden');
+    workspacePanel.setAttribute('aria-hidden', 'true');
+    moduleNav.querySelectorAll('.module-nav__item').forEach((item) => item.classList.remove('is-active'));
+    moduleContent.replaceChildren();
+    updateContinueState();
+    continueButton.focus();
+  });
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PLM Workspace</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="app-header__brand">
+        <span class="app-header__badge">PLM</span>
+        <h1>Product Lifecycle Workspace</h1>
+      </div>
+      <p class="app-header__subtitle">
+        Orchestrate your product creation from concept to launch.
+      </p>
+    </header>
+
+    <main>
+      <section class="panel" id="briefing-panel">
+        <header class="panel__header">
+          <h2>Brand Brief</h2>
+          <p>Set the context for the collection you are working on.</p>
+        </header>
+        <form class="briefing-form" id="briefing-form">
+          <div class="form-row">
+            <label>Brand</label>
+            <div class="toggle-group" role="group" aria-label="Brand">
+              <button type="button" data-brand="Mens">Mens</button>
+              <button type="button" data-brand="Womens">Womens</button>
+            </div>
+          </div>
+          <div class="form-row">
+            <label for="season">Season</label>
+            <select id="season" required>
+              <option value="" disabled selected>Select a season</option>
+              <option>Spring 2025</option>
+              <option>Summer 2025</option>
+              <option>Fall 2025</option>
+              <option>Holiday 2025</option>
+            </select>
+          </div>
+          <div class="form-row">
+            <label for="department">Department</label>
+            <select id="department" required>
+              <option value="" disabled selected>Select a department</option>
+              <option>Design</option>
+              <option>Development</option>
+              <option>Production</option>
+              <option>Merchandising</option>
+            </select>
+          </div>
+          <div class="form-actions">
+            <button id="continue-btn" type="submit" disabled>Continue</button>
+          </div>
+        </form>
+        <aside class="briefing-summary" id="briefing-summary" hidden>
+          <h3>Collection Context Locked</h3>
+          <p>Your selections anchor downstream modules. Reopen the brief to adjust.</p>
+          <dl>
+            <div>
+              <dt>Brand</dt>
+              <dd>-</dd>
+            </div>
+            <div>
+              <dt>Season</dt>
+              <dd>-</dd>
+            </div>
+            <div>
+              <dt>Department</dt>
+              <dd>-</dd>
+            </div>
+          </dl>
+          <button class="briefing-summary__edit" type="button" id="edit-brief">Edit Brief</button>
+        </aside>
+      </section>
+
+      <section class="panel panel--hidden" id="workspace-panel" aria-hidden="true">
+        <header class="panel__header">
+          <div>
+            <h2>Workspace</h2>
+            <p>Select a module to manage your product data.</p>
+          </div>
+          <dl class="context-chip" id="selection-summary">
+            <div>
+              <dt>Brand</dt>
+              <dd>-</dd>
+            </div>
+            <div>
+              <dt>Season</dt>
+              <dd>-</dd>
+            </div>
+            <div>
+              <dt>Department</dt>
+              <dd>-</dd>
+            </div>
+          </dl>
+        </header>
+
+        <nav class="module-nav" aria-label="Workspace modules">
+          <button class="module-nav__item" data-module="article">
+            <span>Article Creation</span>
+            <small>Sketches, specs, and milestones</small>
+          </button>
+          <button class="module-nav__item" data-module="materials">
+            <span>Materials Library</span>
+            <small>Fabrics, trims, components</small>
+          </button>
+          <button class="module-nav__item" data-module="colors">
+            <span>Color Library</span>
+            <small>Palette standards &amp; approvals</small>
+          </button>
+          <button class="module-nav__item" data-module="calendar">
+            <span>Season Calendar</span>
+            <small>Track key deliverables</small>
+          </button>
+        </nav>
+
+        <section class="module-board" id="module-content" aria-live="polite"></section>
+      </section>
+    </main>
+
+    <template id="article-template">
+      <article class="module">
+        <header class="module__header">
+          <h3>Article Creation</h3>
+          <p>Monitor style readiness across the development funnel.</p>
+        </header>
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th>Style</th>
+              <th>Category</th>
+              <th>Status</th>
+              <th>Next Milestone</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </article>
+    </template>
+
+    <template id="materials-template">
+      <article class="module">
+        <header class="module__header">
+          <h3>Materials Library</h3>
+          <p>Reference approved textiles and trims.</p>
+        </header>
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th>Material</th>
+              <th>Composition</th>
+              <th>Supplier</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </article>
+    </template>
+
+    <template id="colors-template">
+      <article class="module">
+        <header class="module__header">
+          <h3>Color Library</h3>
+          <p>Align color approvals across brand touchpoints.</p>
+        </header>
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th>Color</th>
+              <th>Code</th>
+              <th>Finish</th>
+              <th>Approval</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </article>
+    </template>
+
+    <template id="calendar-template">
+      <article class="module">
+        <header class="module__header">
+          <h3>Season Calendar</h3>
+          <p>Stay on top of deadlines and deliverables.</p>
+        </header>
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th>Milestone</th>
+              <th>Owner</th>
+              <th>Due Date</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </article>
+    </template>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,433 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background-color: #f6f7fb;
+  color: #1a1f36;
+  line-height: 1.6;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+main {
+  display: grid;
+  gap: 2.5rem;
+  padding: 0 1.5rem 3rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.app-header {
+  background: radial-gradient(circle at top left, #4f46e5, #4338ca);
+  color: white;
+  padding: 3rem 1.5rem 4rem;
+  text-align: center;
+  margin-bottom: -2rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.app-header::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.2), transparent 55%);
+  pointer-events: none;
+}
+
+.app-header__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.app-header__badge {
+  display: inline-flex;
+  width: 52px;
+  height: 52px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.2);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.app-header__subtitle {
+  max-width: 480px;
+  margin: 1rem auto 0;
+  opacity: 0.85;
+}
+
+.panel {
+  background: white;
+  border-radius: 24px;
+  box-shadow: 0 30px 60px -35px rgba(15, 23, 42, 0.4);
+  padding: 2.5rem;
+  display: grid;
+  gap: 1.75rem;
+}
+
+.panel--hidden {
+  display: none;
+}
+
+.panel--complete .panel__header {
+  border-bottom: 1px solid #f1f5f9;
+  padding-bottom: 1.2rem;
+}
+
+.panel--complete .briefing-form {
+  display: none;
+}
+
+.panel__header h2 {
+  margin: 0;
+  font-size: 1.6rem;
+  color: #111827;
+}
+
+.panel__header p {
+  margin: 0.35rem 0 0;
+  color: #6b7280;
+}
+
+.briefing-form {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.briefing-summary {
+  display: grid;
+  gap: 1rem;
+  background: #f8f9ff;
+  border: 1px dashed #c7d2fe;
+  border-radius: 16px;
+  padding: 1.5rem;
+}
+
+.briefing-summary h3 {
+  margin: 0;
+  font-size: 1.15rem;
+  color: #312e81;
+}
+
+.briefing-summary p {
+  margin: 0;
+  color: #4b5563;
+}
+
+.briefing-summary dl {
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.briefing-summary dt {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #6b7280;
+}
+
+.briefing-summary dd {
+  margin: 0.2rem 0 0;
+  font-weight: 600;
+  color: #312e81;
+}
+
+.briefing-summary__edit {
+  justify-self: flex-start;
+  border: none;
+  background: transparent;
+  color: #4338ca;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+}
+
+.briefing-summary__edit:hover,
+.briefing-summary__edit:focus-visible {
+  text-decoration: underline;
+  outline: none;
+}
+
+.form-row {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.form-row label {
+  font-weight: 600;
+  color: #374151;
+}
+
+.toggle-group {
+  display: inline-flex;
+  background: #f3f4f6;
+  padding: 0.3rem;
+  border-radius: 12px;
+  gap: 0.3rem;
+}
+
+.toggle-group button {
+  border: none;
+  background: transparent;
+  padding: 0.65rem 1.6rem;
+  border-radius: 10px;
+  font-weight: 600;
+  cursor: pointer;
+  color: #4b5563;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.toggle-group button[aria-pressed="true"] {
+  background: white;
+  color: #312e81;
+  box-shadow: 0 10px 25px -15px #312e81;
+}
+
+.toggle-group button:focus-visible,
+.toggle-group button:hover {
+  outline: none;
+  transform: translateY(-1px);
+  color: #312e81;
+}
+
+select {
+  appearance: none;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  background: #f9fafb url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" stroke="%236b7280" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"><path d="M4 6l4 4 4-4"/></svg>') no-repeat right 1rem center;
+  color: #1f2937;
+}
+
+select:focus-visible {
+  outline: 2px solid #4338ca;
+  outline-offset: 2px;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+#continue-btn {
+  padding: 0.9rem 2.2rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(120deg, #4338ca, #2563eb);
+  color: white;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+#continue-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+#continue-btn:not(:disabled):hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 35px -25px #2563eb;
+}
+
+.context-chip {
+  display: inline-flex;
+  gap: 1.5rem;
+  align-items: center;
+  margin: 0;
+}
+
+.context-chip div {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.context-chip dt {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #a1a1aa;
+}
+
+.context-chip dd {
+  margin: 0;
+  font-weight: 600;
+  color: #312e81;
+}
+
+.module-nav {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.module-nav__item {
+  border: 1px solid #e0e7ff;
+  border-radius: 16px;
+  padding: 1.3rem 1.5rem;
+  text-align: left;
+  background: linear-gradient(145deg, #f8f9ff, white);
+  cursor: pointer;
+  display: grid;
+  gap: 0.3rem;
+  font-weight: 600;
+  color: #312e81;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.module-nav__item small {
+  font-weight: 500;
+  color: #6b7280;
+}
+
+.module-nav__item.is-active {
+  border-color: #4338ca;
+  box-shadow: 0 12px 30px -20px #4338ca;
+}
+
+.module-nav__item:hover,
+.module-nav__item:focus-visible {
+  outline: none;
+  transform: translateY(-2px);
+}
+
+.module-board {
+  background: #f8faff;
+  border-radius: 18px;
+  padding: 1.75rem;
+  min-height: 320px;
+  border: 1px solid #e5e7eb;
+}
+
+.module {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.module__header h3 {
+  margin: 0;
+  font-size: 1.35rem;
+  color: #111827;
+}
+
+.module__header p {
+  margin: 0.4rem 0 0;
+  color: #6b7280;
+}
+
+.module__context {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.25rem;
+  border-top: 1px solid #eef2ff;
+  background: #f9fafb;
+  border-radius: 0 0 16px 16px;
+  font-size: 0.95rem;
+  color: #4b5563;
+}
+
+.module__context-label {
+  font-weight: 600;
+}
+
+.module__context-pill {
+  display: inline-flex;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.3rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(67, 56, 202, 0.1);
+  color: #312e81;
+  font-weight: 600;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: white;
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.data-table thead {
+  background: #eef2ff;
+  color: #312e81;
+}
+
+.data-table th,
+.data-table td {
+  padding: 0.85rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.data-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.badge {
+  display: inline-flex;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.badge--success {
+  background: #dcfce7;
+  color: #15803d;
+}
+
+.badge--warning {
+  background: #fef3c7;
+  color: #b45309;
+}
+
+.badge--info {
+  background: #e0f2fe;
+  color: #0369a1;
+}
+
+.badge--neutral {
+  background: #e4e4e7;
+  color: #3f3f46;
+}
+
+@media (max-width: 768px) {
+  .panel {
+    padding: 1.75rem;
+  }
+
+  .briefing-summary dl {
+    grid-template-columns: 1fr;
+  }
+
+  .context-chip {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .module-nav {
+    grid-template-columns: 1fr;
+  }
+
+  .module__context {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a brand brief step that captures brand, season, and department before entering the workspace
- build module navigation for article creation, materials, colors, and calendar tables with contextual summaries
- style the interface with responsive cards and allow reopening the brief for edits

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e1cff44f8c832a99948edb3e1a9493